### PR TITLE
Update comment to match the function name

### DIFF
--- a/email.go
+++ b/email.go
@@ -111,7 +111,7 @@ type unEncryptedAuth struct {
 	username, password string
 }
 
-// InsecureAuth returns an Auth that implements the PLAIN authentication
+// UnEncryptedAuth returns an Auth that implements the PLAIN authentication
 // mechanism as defined in RFC 4616.
 // The returned Auth uses the given username and password to authenticate
 // without checking a TLS connection or host like smtp.PlainAuth does.


### PR DESCRIPTION
This simple change makes `golint` a tiny bit happier by matching the comment to the exported function name.
