### PR TITLE
For a correct Mime encoded Message you need two Line Breaks

### DIFF
--- a/email.go
+++ b/email.go
@@ -107,6 +107,7 @@ func (m *Message) Bytes() []byte {
 
 	buf.WriteString(fmt.Sprintf("Content-Type: %s; charset=utf-8\n\n", m.BodyContentType))
 	buf.WriteString(m.Body)
+	buf.WriteString("\n")
 
 	if len(m.Attachments) > 0 {
 		for _, attachment := range m.Attachments {

--- a/email.go
+++ b/email.go
@@ -105,7 +105,7 @@ func (m *Message) Bytes() []byte {
 		buf.WriteString("--" + boundary + "\n")
 	}
 
-	buf.WriteString(fmt.Sprintf("Content-Type: %s; charset=utf-8\n", m.BodyContentType))
+	buf.WriteString(fmt.Sprintf("Content-Type: %s; charset=utf-8\n\n", m.BodyContentType))
 	buf.WriteString(m.Body)
 
 	if len(m.Attachments) > 0 {


### PR DESCRIPTION
Currently on some mail clients a single line break after the content type of text/html or text/plain would break the message apart.