### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,21 @@ go get github.com/scorredoira/email
 # Usage
 
 ```go
+package email_test
+
+import (
+	"log"
+	"net/mail"
+	"net/smtp"
+
+	"github.com/scorredoira/email"
+)
+
+func Example() {
 	// compose the message
 	m := email.NewMessage("Hi", "this is the body")
 	m.From = mail.Address{Name: "From", Address: "from@example.com"}
-    m.To = []string{"to@example.com"}
-    m.Cc = []string{"cc1@example.com", "cc2@example.com"}
-    m.Bcc = []string{"bcc1@example.com", "bcc2@example.com"}
+	m.To = []string{"to@example.com"}
 
 	// add attachments
 	if err := m.Attach("email.go"); err != nil {
@@ -24,10 +33,11 @@ go get github.com/scorredoira/email
 	}
 
 	// send it
-	auth := smtp.PlainAuth("", "from@example.com", "pwd", "smtp.zoho.com")	
+	auth := smtp.PlainAuth("", "from@example.com", "pwd", "smtp.zoho.com")
 	if err := email.Send("smtp.zoho.com:587", auth, m); err != nil {
 		log.Fatal(err)
 	}
+}
 ```
 
 # Html


### PR DESCRIPTION
The fact that it uses both the identified "email" and "mail" in the example is a bit confusing especially when (like me) you're not aware that there's a net/mail package that needs to be imported.

So I think it would be cleared to put the complete example in the readme.

In any case, thank you for this useful package!