### PR TITLE
Add method to use HTML template in HTML emails instead of HTML via string

### DIFF
--- a/email.go
+++ b/email.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"html/template"
 	"io/ioutil"
 	"mime"
 	"net/mail"
@@ -95,6 +96,24 @@ func (m *Message) Tolist() []string {
 	tolist = append(tolist, m.Bcc...)
 
 	return tolist
+}
+
+// HTMLTemplate parses a HTML template into the body
+func (m *Message) HTMLTemplate(file string, data interface{}) error {
+	t, err := template.ParseFiles(file)
+	if err != nil {
+		return fmt.Errorf("failure parsing template: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err := t.Execute(buf, data); err != nil {
+		return fmt.Errorf("template execution failed: %v", err)
+	}
+
+	m.Body = buf.String()
+	// Force content type to html
+	m.BodyContentType = "text/html"
+	return nil
 }
 
 // Bytes returns the mail data

--- a/email.go
+++ b/email.go
@@ -80,12 +80,12 @@ func newMessage(subject string, body string, bodyContentType string) *Message {
 	return m
 }
 
-// NewMessage returns a new Message that can compose an email with attachments
+// NewMessage returns a new Message that composes an email
 func NewMessage(subject string, body string) *Message {
 	return newMessage(subject, body, "text/plain")
 }
 
-// NewHTMLMessage returns a new Message that can compose an HTML email with attachments
+// NewHTMLMessage returns a new Message that composes an HTML email
 func NewHTMLMessage(subject string, body string) *Message {
 	return newMessage(subject, body, "text/html")
 }
@@ -144,11 +144,13 @@ func (m *Message) Bytes() []byte {
 	boundary := "f46d043c813270fc6b04c2d223da"
 
 	if len(m.Attachments) > 0 {
-		buf.WriteString("Content-Type: multipart/mixed; boundary=" + boundary + "\r\n")
+		buf.WriteString("Content-Type: multipart/mixed; boundary=" + boundary +
+			"\r\n")
 		buf.WriteString("\r\n--" + boundary + "\r\n")
 	}
 
-	buf.WriteString(fmt.Sprintf("Content-Type: %s; charset=utf-8\r\n\r\n", m.BodyContentType))
+	buf.WriteString(fmt.Sprintf("Content-Type: %s; charset=utf-8\r\n\r\n",
+		m.BodyContentType))
 	buf.WriteString(m.Body)
 	buf.WriteString("\r\n")
 
@@ -158,7 +160,8 @@ func (m *Message) Bytes() []byte {
 
 			if attachment.Inline {
 				buf.WriteString("Content-Type: message/rfc822\r\n")
-				buf.WriteString("Content-Disposition: inline; filename=\"" + attachment.Filename + "\"\r\n\r\n")
+				buf.WriteString("Content-Disposition: inline; filename=\"" +
+					attachment.Filename + "\"\r\n\r\n")
 
 				buf.Write(attachment.Data)
 			} else {

--- a/email.go
+++ b/email.go
@@ -91,15 +91,8 @@ func NewHTMLMessage(subject string, body string) *Message {
 
 // Tolist returns all the recipients of the email
 func (m *Message) Tolist() []string {
-	tolist := m.To
-
-	for _, cc := range m.Cc {
-		tolist = append(tolist, cc)
-	}
-
-	for _, bcc := range m.Bcc {
-		tolist = append(tolist, bcc)
-	}
+	tolist := append(m.To, m.Cc...)
+	tolist = append(tolist, m.Bcc...)
 
 	return tolist
 }

--- a/email_test.go
+++ b/email_test.go
@@ -12,7 +12,7 @@ func TestAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if strings.Contains(string(m.Bytes()), "text/calendar") == false {
+	if !strings.Contains(string(m.Bytes()), "text/calendar") {
 		t.Fatal("Issue with mailer")
 	}
 }


### PR DESCRIPTION
Hi,

I've been using your library because of the attachment integration. I have email-templates stored as files which need execution. I've added a method which parses a HTML template and sets it to the body, it also forces the content-type to `text/html`, for these cases.

Example:

```go
package email_test

import (
    "log"
    "net/mail"
    "net/smtp"

    "github.com/scorredoira/email"
)

func Example() {
    // compose the message, both NewMessage and NewHTMLMessage work
    m := email.NewMessage("Hi", "")
    m.From = mail.Address{Name: "From", Address: "from@example.com"}
    m.To = []string{"to@example.com"}

    // parse html template
    if err := m.HTMLTemplate("template.html", map[string]interface{}{"Test":"string"}); err != nil {
        log.Fatal(err)
    }

    // add attachments
    if err := m.Attach("email.go"); err != nil {
        log.Fatal(err)
    }

    // send it
    auth := smtp.PlainAuth("", "from@example.com", "pwd", "smtp.zoho.com")
    if err := email.Send("smtp.zoho.com:587", auth, m); err != nil {
        log.Fatal(err)
    }
}
```

I hope you like it. I've also optimized the `Tolist()` function, it now omits the loops.

Cheers!

Rik