### PR TITLE
Changed 'Date' format from RFC822 to RFC822Z

### DIFF
--- a/email.go
+++ b/email.go
@@ -111,7 +111,7 @@ func (m *Message) Bytes() []byte {
 	buf.WriteString("From: " + m.From.String() + "\r\n")
 
 	t := time.Now()
-	buf.WriteString("Date: " + t.Format(time.RFC822) + "\r\n")
+	buf.WriteString("Date: " + t.Format(time.RFC822Z) + "\r\n")
 
 	buf.WriteString("To: " + strings.Join(m.To, ",") + "\r\n")
 	if len(m.Cc) > 0 {


### PR DESCRIPTION
Some email clients including Microsoft Outlook on OSX treat
the 'Date' field when formatted as RFC822 as +0000, and so add on the
local time zone off-set. For users infront of GMT, this causes emails to
appear to be recieved in the future. For example, an email sent at 12pm
AEST on 2017-07-20, will display in Outlook on OSX as being recieved
at 10:00pm 2017-07-20.

Swapping the date format from RFC822 to RFC822Z (which includes the time
zone) produces the expected behaviour in Outlook on OSX, Outlook on
Windows, Gmail and Mac Mail.