### PR TITLE
Split long filenames

### DIFF
--- a/filenamesplitting_test.go
+++ b/filenamesplitting_test.go
@@ -1,0 +1,42 @@
+package email
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+)
+
+func TestFilenameSplitting(t *testing.T) {
+
+	message := NewMessage("Subject", "Text")
+	message.From = mail.Address{"From", "from@example.com"}
+	message.To = []string{"to@example.com"}
+
+	longstring := "123456789012345678901234567890123456789012345678901234567890123456789012345678901234"
+	filecontent := []byte("Hello World")
+
+	message.AttachBuffer(longstring[0:28], filecontent, false) // 28 -> 40 (base64 and utf8-prefix)
+	message.AttachBuffer(longstring[0:32], filecontent, false) // 32 -> 44
+	message.AttachBuffer(longstring[0:36], filecontent, false) // 36 -> 48
+	message.AttachBuffer(longstring[0:40], filecontent, false) // 40 -> 56
+	message.AttachBuffer(longstring[0:80], filecontent, false) // 80 -> 108
+	message.AttachBuffer(longstring[0:84], filecontent, false) // 84 -> 112
+
+	output := string(message.Bytes())
+	t.Log(output)
+
+	if strings.Count(output, "filename=") != 1 {
+		t.Fatal("Wrong number of filename=")
+	}
+
+	if strings.Count(output, "filename*0=") != 5 {
+		t.Fatal("Wrong number of filename*0=")
+	}
+
+	if strings.Count(output, "filename*1=") != 3 {
+		t.Fatal("Wrong number of filename*1=")
+	}
+	if strings.Count(output, "filename*2=") != 1 {
+		t.Fatal("Wrong number of filename*2=")
+	}
+}


### PR DESCRIPTION
If the filename is too long, some mail services (like gmx.de) and possibly some mail clients refuse to display the attachment at the moment. It must be split like this:

```
Content-Disposition: attachment;
 filename*0="=?UTF-8?B?MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nz";
 filename*1="g5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMj";
 filename*2="M0?="
```