### PR TITLE
Fix Tolist format

### DIFF
--- a/email.go
+++ b/email.go
@@ -120,17 +120,24 @@ func NewHTMLMessage(subject string, body string) *Message {
 
 // Tolist returns all the recipients of the email
 func (m *Message) Tolist() []string {
-	tolist := m.To
+	rcptList := []string{}
 
-	for _, cc := range m.Cc {
-		tolist = append(tolist, cc)
+	toList, _ := mail.ParseAddressList(strings.Join(m.To, ","))
+	for _, to := range toList {
+		rcptList = append(rcptList, to.Address)
 	}
 
-	for _, bcc := range m.Bcc {
-		tolist = append(tolist, bcc)
+	ccList, _ := mail.ParseAddressList(strings.Join(m.Cc, ","))
+	for _, cc := range ccList {
+		rcptList = append(rcptList, cc.Address)
 	}
 
-	return tolist
+	bccList, _ := mail.ParseAddressList(strings.Join(m.Bcc, ","))
+	for _, bcc := range bccList {
+		rcptList = append(rcptList, bcc.Address)
+	}
+
+	return rcptList
 }
 
 // Bytes returns the mail data


### PR DESCRIPTION
This pull request updates `Tolist()` to return a list of email address so that `smtp.Sendmail` can correctly follow the specifications in the SMTP protocol.

According to [section 4.1.1.3](https://tools.ietf.org/html/rfc5321#section-4.1.1.3) of RFC 5321, the format should be like this:
```
      RCPT TO:<userc@d.bar.org>
```

As can be seen in lines [356-360](https://github.com/golang/go/blob/master/src/net/smtp/smtp.go#L356-L360) and [266-272](https://github.com/golang/go/blob/master/src/net/smtp/smtp.go#L266-L272) of `net/smtp/smtp.go`, the `to []string` list of recipients, is put on to the SMTP stream without any further processing. The relevant line is line 270:
```
	_, _, err := c.cmd(25, "RCPT TO:<%s>", to)
```

Since the package `net/smtp` does not do any further processing of the list of strings (email addresses) passed, the list passed to `email.Send` (and thereby, the list passed to `smtp.Sendmail`), should be a list of plain email addresses, instead of RFC 5322 addresses.